### PR TITLE
Updated population's `make_next_generation` method to bias towards best members of the prior generation

### DIFF
--- a/lib/darwinning/population.rb
+++ b/lib/darwinning/population.rb
@@ -45,14 +45,11 @@ module Darwinning
 
     def make_next_generation!
       temp_members = members
-      used_members = []
       new_members = []
 
       until new_members.length == members.length / 2
-        m1 = weighted_select(members - used_members)
-        used_members << m1
-        m2 = weighted_select(members - used_members)
-        used_members << m2
+        m1 = weighted_select(members)
+        m2 = weighted_select(members)
 
         new_members << apply_pairwise_evolutions(organism, m1, m2)
       end

--- a/lib/darwinning/population.rb
+++ b/lib/darwinning/population.rb
@@ -47,14 +47,13 @@ module Darwinning
       temp_members = members
       new_members = []
 
-      until new_members.length == members.length / 2
+      until new_members.length == members.length
         m1 = weighted_select(members)
         m2 = weighted_select(members)
 
-        new_members << apply_pairwise_evolutions(organism, m1, m2)
+        new_members += apply_pairwise_evolutions(organism, m1, m2)
       end
 
-      new_members.flatten!
       @members = apply_non_pairwise_evolutions(new_members)
       @history << @members
       @generation += 1


### PR DESCRIPTION
Hello! Thanks for the awesome library, it's been a treat to use.

One issue that I had though, was that the current implementation of the parent selection in `population.rb` is set up such that every entry in the parent generation is guaranteed to have exactly two children in the following generation, whereas the [traditional implementation of a roulette-wheel selection algorithm](http://geneticalgorithms.ai-depot.com/Tutorial/Overview.html) biases towards the more-fit members of a population having more children in the next generation and the less fit parents might not have any children at all.

This changed provided optimal solutions for me in significantly fewer generations than the previous implementation so I figured I'd just submit it as a straight up switch, but if you'd prefer I'd be happy to reimplement it as toggled option or something like that?

Thanks!


Evan