### PR TITLE
Raise exception is population size is invalid

### DIFF
--- a/lib/darwinning/population.rb
+++ b/lib/darwinning/population.rb
@@ -44,7 +44,8 @@ module Darwinning
     end
 
     def make_next_generation!
-      temp_members = members
+      verify_population_size_is_even_and_positive!
+
       new_members = []
 
       until new_members.length == members.length
@@ -86,6 +87,12 @@ module Darwinning
     end
 
     private
+
+    def verify_population_size_is_even_and_positive!
+      unless @population_size.even? && @population_size.positive?
+        raise "Population size must be an even and positive number!"
+      end
+    end
 
     def build_member
       member = organism.new

--- a/spec/population_spec.rb
+++ b/spec/population_spec.rb
@@ -6,7 +6,7 @@ describe Darwinning::Population do
       organism: Triple, population_size: 10, fitness_goal: 0
     )
   }
-  
+
   it "fitness goal should be set to 0" do
     expect(pop_triple.fitness_goal).to eq 0
   end
@@ -25,6 +25,28 @@ describe Darwinning::Population do
 
     expect(pop_triple.generation).to eq 1
     expect(pop_triple.members).not_to eq old_members
+  end
+
+  describe "#make_next_generation!" do
+    context "with a specified odd-number for population size" do
+      it "raises an exception" do
+        population = Darwinning::Population.new(
+          organism: Triple, fitness_goal: 0, population_size: 3
+        )
+
+        expect { population.make_next_generation! }.to raise_error(RuntimeError)
+      end
+    end
+
+    context "with a specified not-positive number for population size" do
+      it "raises an exception" do
+        population = Darwinning::Population.new(
+          organism: Triple, fitness_goal: 0, population_size: 0
+        )
+
+        expect { population.make_next_generation! }.to raise_error(RuntimeError)
+      end
+    end
   end
 
   describe "#history" do


### PR DESCRIPTION
Creating a population with a `population_size` of an odd number results
in `Population#make_next_generation!` going into an infinite loop, as
the membership of the new population increases in size by pairs, passing
the desired population size and continuing indefinitely.

While this issue made sense after considering what breeding pairs does,
it did result in several futile attempts to track down what behavior was
causing an infinite loop.

This change adds two checks, the first that the desired population size
is even, and the second that the number is positive. If either of those
checks fails, we halt execution and raise a runtime exception.

Additionally deleted a line of code that assigned a temporary variable
that was never accessed again.