### PR TITLE
Remove unused temporary variable assignment

### DIFF
--- a/lib/darwinning/evolution_types/mutation.rb
+++ b/lib/darwinning/evolution_types/mutation.rb
@@ -31,7 +31,6 @@ module Darwinning
       # Selects a random genotype from the organism and re-expresses its gene
       def re_express_random_genotype(member)
         random_index = (0..member.genotypes.length - 1).to_a.sample
-        new_gene = member.genes[random_index].express
         member.genotypes[random_index] = member.genes[random_index].express
         member
       end


### PR DESCRIPTION
In `EvolutionTypes::Mutation#re_express_random_genotype` after the
random genotype is selected, it gets expressed twice, with the second
expression being assigned. The first expression is assigned to a
temporary variable and then never accessed again.