### PR TITLE
Don't create a new string for frequent breeding comparison

### DIFF
--- a/lib/darwinning/evolution_types/reproduction.rb
+++ b/lib/darwinning/evolution_types/reproduction.rb
@@ -33,7 +33,7 @@ module Darwinning
 
       def new_member_from_genotypes(organism_klass, genotypes)
         new_member = organism_klass.new
-        if organism_klass.superclass.to_s == "Darwinning::Organism"
+        if organism_klass.superclass == Darwinning::Organism
           new_member.genotypes = genotypes
         else
           new_member.genes.each do |gene|
@@ -60,7 +60,7 @@ module Darwinning
         [genotypes1, genotypes2]
       end
 
-      def random_swap(m1, m2)        
+      def random_swap(m1, m2)
         genotypes1 = {}
         genotypes2 = {}
 
@@ -69,7 +69,7 @@ module Darwinning
           g2_parent = [m1,m2].sample
 
           genotypes1[gene] = g1_parent.genotypes[gene]
-          genotypes2[gene] = g2_parent.genotypes[gene]          
+          genotypes2[gene] = g2_parent.genotypes[gene]
         end
 
         [genotypes1, genotypes2]

--- a/lib/darwinning/population.rb
+++ b/lib/darwinning/population.rb
@@ -89,7 +89,7 @@ module Darwinning
 
     def build_member
       member = organism.new
-      unless member.class.superclass.to_s == "Darwinning::Organism"
+      unless member.class.superclass == Darwinning::Organism
         member.class.genes.each do |gene|
           gene_expression = gene.express
           member.send("#{gene.name}=", gene_expression)

--- a/lib/darwinning/version.rb
+++ b/lib/darwinning/version.rb
@@ -1,3 +1,3 @@
 module Darwinning
-  VERSION = "0.1.0"
+  VERSION = "0.1.0".freeze
 end


### PR DESCRIPTION
Each time we create a new member a check is made to check if the
organism's class is `Darwinning::Organism`. This check can be performed
by comparing the class names with existing constants rather than
creating a new string for each comparison, which uses more memory and
may be less performant across hundreds of thousands of operations during
evolution.