### PR TITLE
Update Population#make_next_generation! to handle odd population sizes

### DIFF
--- a/lib/darwinning/population.rb
+++ b/lib/darwinning/population.rb
@@ -44,16 +44,19 @@ module Darwinning
     end
 
     def make_next_generation!
-      verify_population_size_is_even_and_positive!
+      verify_population_size_is_positive!
 
       new_members = []
 
-      until new_members.length == members.length
+      until new_members.length >= members.length
         m1 = weighted_select(members)
         m2 = weighted_select(members)
 
         new_members += apply_pairwise_evolutions(m1, m2)
       end
+
+      # In the case of an odd population size, we likely added one too many members.
+      new_members.pop if new_members.length > members.length
 
       @members = apply_non_pairwise_evolutions(new_members)
       @history << @members
@@ -88,9 +91,9 @@ module Darwinning
 
     private
 
-    def verify_population_size_is_even_and_positive!
-      unless @population_size.even? && @population_size.positive?
-        raise "Population size must be an even and positive number!"
+    def verify_population_size_is_positive!
+      unless @population_size.positive?
+        raise "Population size must be a positive number!"
       end
     end
 

--- a/spec/population_spec.rb
+++ b/spec/population_spec.rb
@@ -29,12 +29,12 @@ describe Darwinning::Population do
 
   describe "#make_next_generation!" do
     context "with a specified odd-number for population size" do
-      it "raises an exception" do
+      it "does not change the member count" do
         population = Darwinning::Population.new(
           organism: Triple, fitness_goal: 0, population_size: 3
         )
 
-        expect { population.make_next_generation! }.to raise_error(RuntimeError)
+        expect { population.make_next_generation! }.not_to change{ population.members.length }
       end
     end
 


### PR DESCRIPTION
Context: There was an infinite loop prior to validation check added in: https://github.com/dorkrawk/darwinning/commit/95c6c4c9bf853b0cb0ebdf939ae912d174b66f13

This commit allows an extra pair to be added to the population, but terminates
the loop if there are more new members than desired. There is a follow up
check to `pop` off the last added member if that occurred.

Kept the check in place that the population size needs to a positive
number since that seems sensible.