### PR TITLE
Fix bug within the Mutation evolution type

### DIFF
--- a/lib/darwinning/evolution_types/mutation.rb
+++ b/lib/darwinning/evolution_types/mutation.rb
@@ -31,7 +31,14 @@ module Darwinning
       # Selects a random genotype from the organism and re-expresses its gene
       def re_express_random_genotype(member)
         random_index = (0..member.genotypes.length - 1).to_a.sample
-        member.genotypes[random_index] = member.genes[random_index].express
+        gene = member.genes[random_index]
+
+        if member.class.superclass == Darwinning::Organism
+          member.genotypes[gene] = gene.express
+        else
+          member.send("#{gene.name}=", gene.express)
+        end
+
         member
       end
     end

--- a/spec/classes/new_single.rb
+++ b/spec/classes/new_single.rb
@@ -1,0 +1,14 @@
+class NewSingle
+  include Darwinning
+
+  GENE_RANGES = {
+    first_digit: (0..9)
+  }
+
+  attr_accessor :first_digit
+
+  def fitness
+    # Try to get the digit to equal 15
+    (first_digit - 15).abs
+  end
+end

--- a/spec/classes/single.rb
+++ b/spec/classes/single.rb
@@ -1,0 +1,11 @@
+class Single < Darwinning::Organism
+  @name = "Single"
+  @genes = [
+    Darwinning::Gene.new(name: "first digit", value_range: (0..9))
+  ]
+
+  def fitness
+    # Try to get the digit to equal 15
+    (genotypes.values.inject{ |sum, x| sum + x } - 15).abs
+  end
+end

--- a/spec/evolution_types/mutation_spec.rb
+++ b/spec/evolution_types/mutation_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe Darwinning::EvolutionTypes::Mutation do
+
+  describe '#evolve' do
+    context 'when the mutation is triggered' do
+      # Use a mutation_rate of 1 ... which means a 100% chance of mutation.
+      subject { described_class.new(mutation_rate: 1.0) }
+      let(:new_gene_variant) { double }
+
+      before do
+        allow(gene).to receive(:express).and_return(new_gene_variant)
+      end
+
+      shared_examples_for 'a mutation that updates the genotype of the member' do
+        before { subject.evolve([member]) }
+
+        it "modifies the member's genotype to be the new expression of the gene" do
+          expect(member.genotypes[gene]).to eq(new_gene_variant)
+        end
+      end
+
+      context 'with a subclass of Organism' do
+        let(:member) { Single.new }
+        let(:gene) { member.genes[0] }
+
+        it_behaves_like 'a mutation that updates the genotype of the member'
+      end
+
+      context 'with a class that includes Darwinning' do
+        let(:member) { NewSingle.new }
+        let(:gene) { Darwinning::Gene.new(name: :first_digit, value_range: (0..9)) }
+
+        before do
+          allow(Darwinning::Gene).to receive(:new)
+            .with(name: :first_digit, value_range: (0..9))
+            .and_return(gene)
+        end
+
+        it_behaves_like 'a mutation that updates the genotype of the member'
+      end
+    end
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,5 @@
 require 'darwinning'
-require './spec/classes/triple'
-require './spec/classes/new_triple'
-require './spec/classes/chimps'
+
+Dir[
+  File.join(File.dirname(__FILE__), './classes/*.rb'),
+].each { |file| require file }


### PR DESCRIPTION
The existing code did not update the member's genotypes when
re-expressing a gene.

This change borrows the assignment techniques from the `Reproduction`
evolution type which observes the distinction between the two styles:
... subclass Organism and the 'include Darwinning' style.
... see [reproduction.rb#L36-L42](https://github.com/dorkrawk/darwinning/blob/ef958c6b22a744a0259606901442ffb7c785cf84/lib/darwinning/evolution_types/reproduction.rb#L36-L42)

In the case of the 'include' style
... the member's #genotypes method returns a new Hash each time its called
... see: [darwinning.rb#L57](https://github.com/dorkrawk/darwinning/blob/ef958c6b22a744a0259606901442ffb7c785cf84/lib/darwinning.rb#L57)
And so we need to make use of the contract that there are accessors
for each of the genes, and send messages to the setter methods.

In the case of the Organism subclass
... we can modify the member.genotypes directly,
... but we need to use the gene object as the key to update the value.

This commit also adds two supporting files to spec/classes
... they each have only one gene to facilitate testing.