### PR TITLE
Add population reference to organism

### DIFF
--- a/darwinning.gemspec
+++ b/darwinning.gemspec
@@ -3,6 +3,7 @@ require "./lib/darwinning/version"
 Gem::Specification.new do |s|
 	s.name = 'darwinning'
 	s.version = Darwinning::VERSION
+	s.required_ruby_version = '>= 2.0'
 
 	s.authors = ['Dave Schwantes']
 	s.email = 'dave.schwantes@gmail.com'

--- a/lib/darwinning.rb
+++ b/lib/darwinning.rb
@@ -10,6 +10,8 @@ require_relative 'darwinning/monkey_patch'
 module Darwinning
   extend Config
 
+  attr_accessor :population
+
   def self.included(base)
     def base.genes
       gene_ranges.map { |k,v| Gene.new(name: k, value_range: v) }

--- a/lib/darwinning/evolution_types/reproduction.rb
+++ b/lib/darwinning/evolution_types/reproduction.rb
@@ -9,8 +9,8 @@ module Darwinning
         @crossover_method = options.fetch(:crossover_method, :alternating_swap)
       end
 
-      def evolve(m1, m2)
-        sexytimes(m1, m2)
+      def evolve(m1, m2, population)
+        sexytimes(m1, m2, population)
       end
 
       def pairwise?
@@ -19,20 +19,21 @@ module Darwinning
 
       protected
 
-      def sexytimes(m1, m2)
+      def sexytimes(m1, m2, population)
         raise "Only organisms of the same type can breed" unless m1.class == m2.class
 
         new_genotypes = send(@crossover_method, m1, m2)
 
         organism_klass = m1.class
-        organism1 = new_member_from_genotypes(organism_klass, new_genotypes.first)
-        organism2 = new_member_from_genotypes(organism_klass, new_genotypes.last)
+        organism1 = new_member_from_genotypes(organism_klass, new_genotypes.first, population)
+        organism2 = new_member_from_genotypes(organism_klass, new_genotypes.last, population)
 
         [organism1, organism2]
       end
 
-      def new_member_from_genotypes(organism_klass, genotypes)
+      def new_member_from_genotypes(organism_klass, genotypes, population)
         new_member = organism_klass.new
+        new_member.population = population
         if organism_klass.superclass == Darwinning::Organism
           new_member.genotypes = genotypes
         else

--- a/lib/darwinning/organism.rb
+++ b/lib/darwinning/organism.rb
@@ -29,12 +29,13 @@ module Darwinning
   class Organism
     include ClassLevelInheritableAttributes
     inheritable_attributes :genes, :name
-    attr_accessor :genotypes, :fitness, :name, :genes
+    attr_accessor :fitness, :genes, :genotypes, :name, :population
 
     @genes = []  # Gene instances
     @name = ""
 
-    def initialize(genotypes = {})
+    def initialize(genotypes = {}, population: nil)
+      @population = population
       if genotypes == {}
         # fill genotypes with expressed Genes
         @genotypes = {}

--- a/lib/darwinning/population.rb
+++ b/lib/darwinning/population.rb
@@ -127,6 +127,7 @@ module Darwinning
 
     def build_member
       member = organism.new
+      member.population = self
       unless member.class < Darwinning::Organism
         member.class.genes.each do |gene|
           gene_expression = gene.express
@@ -184,7 +185,7 @@ module Darwinning
     def apply_pairwise_evolutions(m1, m2)
       evolution_types.inject([m1, m2]) do |ret, evolution_type|
         if evolution_type.pairwise?
-          evolution_type.evolve(*ret)
+          evolution_type.evolve(*ret, self)
         else
           ret
         end

--- a/spec/organism_spec.rb
+++ b/spec/organism_spec.rb
@@ -1,8 +1,9 @@
 require_relative 'spec_helper'
 
 describe Darwinning::Organism do
-  let(:org) { Darwinning::Organism.new }
-  let(:triple) { Triple.new }
+  let(:pop) { Darwinning::Population.new(organism: Triple, population_size: 10, fitness_goal: 0) }
+  let(:org) { Darwinning::Organism.new(population: pop) }
+  let(:triple) { Triple.new(population: pop) }
 
   it "name should default to blank" do
     expect(org.name).to eq ""
@@ -32,4 +33,7 @@ describe Darwinning::Organism do
     expect(triple.genotypes.length).to eq 3
   end
 
+  it "can reference its population" do
+    expect(org.population).to eq(pop)
+  end
 end

--- a/spec/population_spec.rb
+++ b/spec/population_spec.rb
@@ -27,6 +27,12 @@ describe Darwinning::Population do
     expect(pop_triple.members).not_to eq old_members
   end
 
+  it "passes itself to each member" do
+    expect(pop_triple.members.all? { |m| m.population == pop_triple }).to be
+    pop_triple.make_next_generation!
+    expect(pop_triple.members.all? { |m| m.population == pop_triple }).to be
+  end
+
   describe "#make_next_generation!" do
     context "with a specified odd-number for population size" do
       it "does not change the member count" do


### PR DESCRIPTION
## What 🤔 
- Add a reference to `population` to `Organism` and pass it down through each generation.
- Set required minimum ruby version to 2.0 to ensure support for Keyword Arguments

## Why 😃 
Currently working on a project in which I load & cache data from a database in a `Population` that is used in its organism's `fitness` method. Letting organisms reference their population is a clean way to accomplish this, which may also be helpful in other use-cases. It may even provide a means to get around the limitation brought up in https://github.com/dorkrawk/darwinning/issues/17 in some cases.