### PR TITLE
Too much history - Resolves #19

### DIFF
--- a/lib/darwinning/evolution_types/reproduction.rb
+++ b/lib/darwinning/evolution_types/reproduction.rb
@@ -1,6 +1,7 @@
 module Darwinning
   module EvolutionTypes
     class Reproduction
+      class IncompatibleOrganismsError < RuntimeError; end
 
       # Available crossover_methods:
       #   :alternating_swap
@@ -20,7 +21,7 @@ module Darwinning
       protected
 
       def sexytimes(m1, m2)
-        raise "Only organisms of the same type can breed" unless m1.class == m2.class
+        verify_organism_compatability!(m1, m2)
 
         new_genotypes = send(@crossover_method, m1, m2)
 
@@ -73,6 +74,13 @@ module Darwinning
         end
 
         [genotypes1, genotypes2]
+      end
+
+      private
+
+      def verify_organism_compatability!(m1, m2)
+      return if m1.class == m2.class
+      raise IncompatibleOrganismsError.new('Only organisms of the same type can breed')
       end
     end
   end

--- a/lib/darwinning/population.rb
+++ b/lib/darwinning/population.rb
@@ -1,5 +1,6 @@
 module Darwinning
   class Population
+    class SizeError < RuntimeError; end
 
     attr_reader :members, :generations_limit, :fitness_goal, :fitness_objective,
                 :organism, :population_size, :generation,
@@ -42,7 +43,7 @@ module Darwinning
     end
 
     def set_members_fitness!(fitness_values)
-      throw "Invaid number of fitness values for population size" if fitness_values.size != members.size
+      verify_fitness_values!
       members.to_enum.each_with_index { |m, i| m.fitness = fitness_values[i] }
       sort_members
     end
@@ -123,9 +124,13 @@ module Darwinning
     end
 
     def verify_population_size_is_positive!
-      unless @population_size.positive?
-        raise "Population size must be a positive number!"
-      end
+      return if @population_size.positive?
+      raise SizeError.new('Population size must be a positive number')
+    end
+
+    def verify_fitness_values!
+      return if fitness_values.size == members.size
+      raise FitnessValueError.new('Invaid number of fitness values for population size')
     end
 
     def build_member

--- a/lib/darwinning/population.rb
+++ b/lib/darwinning/population.rb
@@ -22,10 +22,15 @@ module Darwinning
       @history = []
 
       build_population(@population_size)
+      initialize_history
     end
 
     def build_population(population_size)
       population_size.times do |i|
+    def initialize_history
+      return if @history.any?
+      @history << sorted_members
+    end
         @members << build_member
       end
     end
@@ -44,8 +49,6 @@ module Darwinning
 
     def make_next_generation!
       verify_population_size_is_positive!
-      sort_members
-      @history << @members
 
       new_members = []
 

--- a/spec/population_spec.rb
+++ b/spec/population_spec.rb
@@ -44,7 +44,7 @@ describe Darwinning::Population do
           organism: Triple, fitness_goal: 0, population_size: 0
         )
 
-        expect { population.make_next_generation! }.to raise_error(RuntimeError)
+        expect { population.make_next_generation! }.to raise_error(Darwinning::Population::SizeError)
       end
     end
   end


### PR DESCRIPTION
The flaky tests were a result of the history array being added to twice for each generation.

The PR resolve the double history post and cleans up some of the population class.