### PR TITLE
Add OpenTSP

### DIFF
--- a/examples/open_tsp.rb
+++ b/examples/open_tsp.rb
@@ -1,0 +1,81 @@
+require 'darwinning'
+require 'pp'
+
+class OpenTSP < Darwinning::Organism
+  CANT_NODES = 5
+
+  OpenTSP::CANT_NODES.times do |s|
+    @genes << Darwinning::Gene.new(
+      name: s, value_range: (0..OpenTSP::CANT_NODES - 1)
+    )
+  end
+
+  def fitness
+    return Float::INFINITY if repeated_node
+
+    fitness = 0
+    previous_node_id = nil
+
+    genotypes.each_value do |node_id|
+      fitness += distance(previous_node_id, node_id) if previous_node_id
+
+      previous_node_id = node_id
+    end
+
+    fitness
+  end
+
+  def distance_matrix
+    [
+      [ 0,  10,  20,  30,  100],
+      [10,   0,  10,  20,  100],
+      [20,  10,   0,  10,  100],
+      [30,  20,  10,   0,  100],
+      [100, 100, 100, 100,  0 ]
+    ]
+  end
+
+  def distance(from_node_id, to_node_id)
+    distance_matrix[from_node_id][to_node_id]
+  end
+
+  def repeated_node
+    genotypes.values.uniq.length < genotypes.values.length
+  end
+end
+
+class OpenTSPPopulation < Darwinning::Population
+  def build_population(population_size)
+    population_size.times do
+      sample = (0..OpenTSP::CANT_NODES - 1).to_a.shuffle
+
+      member = OpenTSP.new
+      member.genotypes.zip(sample).each do |genotype, value|
+        member.genotypes[genotype[0]] = value
+      end
+
+      @members << member
+    end
+  end
+end
+
+
+evolution_types = [
+  Darwinning::EvolutionTypes::Reproduction.new(
+    crossover_method: :pmx_swap
+  ),
+  Darwinning::EvolutionTypes::Mutation.new(
+    mutation_method: :interchange_random_genotypes,
+    mutation_rate: 0.10
+  )
+]
+
+open_tsp_pop = OpenTSPPopulation.new(
+  organism: OpenTSP, population_size: 20,
+  fitness_goal: 0, generations_limit: 200,
+  evolution_types: evolution_types
+)
+open_tsp_pop.evolve!
+
+pp "Best member: #{open_tsp_pop.best_member.genotypes.values}"
+pp "Best member: #{open_tsp_pop.best_member.fitness}"

--- a/lib/darwinning/evolution_types/mutation.rb
+++ b/lib/darwinning/evolution_types/mutation.rb
@@ -1,11 +1,11 @@
 module Darwinning
   module EvolutionTypes
-
     class Mutation
-      attr_reader :mutation_rate
+      attr_reader :mutation_method, :mutation_rate
 
       def initialize(options = {})
         @mutation_rate = options.fetch(:mutation_rate, 0.0)
+        @mutation_method = options.fetch(:mutation_method, :re_express_random_genotype)
       end
 
       def evolve(members)
@@ -21,7 +21,7 @@ module Darwinning
       def mutate(members)
         members.map do |member|
           if rand < mutation_rate
-            re_express_random_genotype(member)
+            send(mutation_method, member)
           else
             member
           end
@@ -41,7 +41,24 @@ module Darwinning
 
         member
       end
-    end
 
+      # Selects two random genotypes and swaps them
+      def interchange_random_genotypes(member)
+        gene1, gene2 = member.genes.sample(2)
+
+        genotype1 = member.genotypes[gene1]
+        genotype2 = member.genotypes[gene2]
+
+        if member.class.superclass == Darwinning::Organism
+          member.genotypes[gene1] = genotype2
+          member.genotypes[gene2] = genotype1
+        else
+          member.send("#{gene1.name}=", genotype2)
+          member.send("#{gene2.name}=", genotype1)
+        end
+
+        member
+      end
+    end
   end
 end

--- a/lib/darwinning/evolution_types/reproduction.rb
+++ b/lib/darwinning/evolution_types/reproduction.rb
@@ -2,9 +2,12 @@ module Darwinning
   module EvolutionTypes
     class Reproduction
 
+      attr_reader :crossover_method
+
       # Available crossover_methods:
       #   :alternating_swap
       #   :random_swap
+      #   :pmx_swap
       def initialize(options = {})
         @crossover_method = options.fetch(:crossover_method, :alternating_swap)
       end
@@ -22,7 +25,7 @@ module Darwinning
       def sexytimes(m1, m2)
         raise "Only organisms of the same type can breed" unless m1.class == m2.class
 
-        new_genotypes = send(@crossover_method, m1, m2)
+        new_genotypes = send(crossover_method, m1, m2)
 
         organism_klass = m1.class
         organism1 = new_member_from_genotypes(organism_klass, new_genotypes.first)
@@ -70,6 +73,41 @@ module Darwinning
 
           genotypes1[gene] = g1_parent.genotypes[gene]
           genotypes2[gene] = g2_parent.genotypes[gene]
+        end
+
+        [genotypes1, genotypes2]
+      end
+
+      def pmx_swap(m1, m2)
+        genotypes1 = {}
+        genotypes2 = {}
+        genotypes1_interchange = {}
+        genotypes2_interchange = {}
+
+        swap_point = rand(m1.genes.size / 2)
+
+        m1.genes.each_with_index do |gene, i|
+          m1_node = m1.genotypes[gene]
+          m2_node = m2.genotypes[gene]
+
+          if i <= swap_point
+            genotypes1_interchange[m2_node] = m1_node
+            genotypes2_interchange[m1_node] = m2_node
+            genotypes1[gene] = m2_node
+            genotypes2[gene] = m1_node
+          else
+            key1 = m1_node
+            while genotypes1_interchange.key?(key1)
+              key1 = genotypes1_interchange[key1]
+            end
+            genotypes1[gene] = key1
+
+            key2 = m2_node
+            while genotypes2_interchange.key?(key2)
+              key2 = genotypes2_interchange[key2]
+            end
+            genotypes2[gene] = key2
+          end
         end
 
         [genotypes1, genotypes2]

--- a/spec/evolution_types/mutation_spec.rb
+++ b/spec/evolution_types/mutation_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe Darwinning::EvolutionTypes::Mutation do
-
   describe '#evolve' do
     context 'when the mutation is triggered' do
       # Use a mutation_rate of 1 ... which means a 100% chance of mutation.
@@ -40,6 +39,45 @@ describe Darwinning::EvolutionTypes::Mutation do
         it_behaves_like 'a mutation that updates the genotype of the member'
       end
     end
-  end
 
+    context 'when using interchange_random_genotypes' do
+      subject { described_class.new(mutation_method: :interchange_random_genotypes, mutation_rate: 1.0) }
+
+      shared_examples_for 'a mutation that interchange two genotypes of the member' do
+        let!(:previous_genotypes) { member.genotypes.values }
+        before { subject.evolve([member]) }
+
+        it "modifies the member's genotype to be the new expression of the gene" do
+          expect(member.genotypes.values).to_not eq(previous_genotypes)
+          expect(member.genotypes.values.sort).to eq(previous_genotypes.sort)
+        end
+      end
+
+      context 'with a subclass of Organism' do
+        let(:member) { Triple.new }
+
+        before do
+          sample = [1, 2, 3]
+          member.genotypes.zip(sample).each do |genotype, value|
+            member.genotypes[genotype[0]] = value
+          end
+        end
+
+        it_behaves_like 'a mutation that interchange two genotypes of the member'
+      end
+
+      context 'with a class that includes Darwinning' do
+        let(:member) { NewTriple.new }
+
+        before do
+          sample = [1, 2, 3]
+          member.genes.zip(sample).each do |gene, value|
+            member.send("#{gene.name}=", value)
+          end
+        end
+
+        it_behaves_like 'a mutation that interchange two genotypes of the member'
+      end
+    end
+  end
 end

--- a/spec/evolution_types/reproduction_spec.rb
+++ b/spec/evolution_types/reproduction_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+describe Darwinning::EvolutionTypes::Reproduction do
+  describe '#evolve' do
+    context 'when using pmx_swap' do
+      subject { described_class.new(crossover_method: :pmx_swap) }
+
+      shared_examples_for 'a crossover method that mixes two parents' do
+        let!(:previous_parent1_genotypes) { parent1.genotypes.values }
+        let!(:previous_parent2_genotypes) { parent2.genotypes.values }
+
+        it "modifies the member's genotype to be the new expression of the gene" do
+          child1, child2 = subject.evolve(parent1, parent2)
+
+          expect(parent1.genotypes.values).to eq(previous_parent1_genotypes)
+          expect(parent2.genotypes.values).to eq(previous_parent2_genotypes)
+          expect(child1.genotypes.values).to eq([2, 1, 3])
+          expect(child2.genotypes.values).to eq([1, 3, 2])
+        end
+      end
+
+      context 'with a subclass of Organism' do
+        let(:parent1) { Triple.new }
+        let(:parent2) { Triple.new }
+
+        before do
+          sample1 = [1, 2, 3]
+          parent1.genotypes.zip(sample1).each do |genotype, value|
+            parent1.genotypes[genotype[0]] = value
+          end
+          sample2 = [2, 3, 1]
+          parent2.genotypes.zip(sample2).each do |genotype, value|
+            parent2.genotypes[genotype[0]] = value
+          end
+        end
+
+        it_behaves_like 'a crossover method that mixes two parents'
+      end
+
+      context 'with a class that includes Darwinning' do
+        let(:parent1) { NewTriple.new }
+        let(:parent2) { NewTriple.new }
+
+        before do
+          sample1 = [1, 2, 3]
+          parent1.genes.zip(sample1).each do |gene, value|
+            parent1.send("#{gene.name}=", value)
+          end
+          sample2 = [2, 3, 1]
+          parent2.genes.zip(sample2).each do |gene, value|
+            parent2.send("#{gene.name}=", value)
+          end
+        end
+
+        it_behaves_like 'a crossover method that mixes two parents'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently the gem couldn't be used to solve TSP instances.

This PR adds a new mutation method and a new crossover method that makes sense for TSP (does not generate invalid individuals) and also an example that builds the initial population with only valid individuals.

- [x] Missing tests